### PR TITLE
Test `API` class

### DIFF
--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
@@ -39,13 +39,13 @@ class APITest {
 
     @Test
     fun testLinearAPI() {
-        val api = EmptyLinearAPI()
+        val linearAPI = EmptyLinearAPI()
         val linearOpMode = EmptyLinearOpMode()
 
-        api.init(linearOpMode)
+        linearAPI.init(linearOpMode)
 
-        assertSame(linearOpMode, api.accessOpMode())
-        assertSame(linearOpMode, api.accessLinearOpMode())
+        assertSame(linearOpMode, linearAPI.accessOpMode())
+        assertSame(linearOpMode, linearAPI.accessLinearOpMode())
     }
 
     @Test
@@ -78,9 +78,9 @@ class APITest {
 
     @Test
     fun testInitLinearAPIWithoutLinearOpMode() {
-        val api = EmptyLinearAPI()
+        val linearAPI = EmptyLinearAPI()
         val opMode = EmptyOpMode()
 
-        assertFailsWith<InitLinearAPIWithoutLinearOpMode> { api.init(opMode) }
+        assertFailsWith<InitLinearAPIWithoutLinearOpMode> { linearAPI.init(opMode) }
     }
 }

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
@@ -1,8 +1,10 @@
 package org.firstinspires.ftc.teamcode.core
 
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 class APITest {
     private open class EmptyAPI : API() {
@@ -19,6 +21,31 @@ class APITest {
         override fun init() {}
 
         override fun loop() {}
+    }
+
+    private class EmptyLinearOpMode : LinearOpMode() {
+        override fun runOpMode() {}
+    }
+
+    @Test
+    fun testAPI() {
+        val api = EmptyAPI()
+        val opMode = EmptyOpMode()
+
+        api.init(opMode)
+
+        assertSame(opMode, api.accessOpMode())
+    }
+
+    @Test
+    fun testLinearAPI() {
+        val api = EmptyLinearAPI()
+        val linearOpMode = EmptyLinearOpMode()
+
+        api.init(linearOpMode)
+
+        assertSame(linearOpMode, api.accessOpMode())
+        assertSame(linearOpMode, api.accessLinearOpMode())
     }
 
     @Test

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 
-class APITest {
+internal class APITest {
     private open class EmptyAPI : API() {
         fun accessOpMode() = this.opMode
 

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
@@ -28,7 +28,7 @@ internal class APITest {
     }
 
     @Test
-    fun testAPI() {
+    fun testAPIOpModeAccess() {
         val api = EmptyAPI()
         val opMode = EmptyOpMode()
 
@@ -38,7 +38,7 @@ internal class APITest {
     }
 
     @Test
-    fun testLinearAPI() {
+    fun testLinearAPIOpModeAccess() {
         val linearAPI = EmptyLinearAPI()
         val linearOpMode = EmptyLinearOpMode()
 
@@ -71,6 +71,7 @@ internal class APITest {
 
     @Test
     fun testIllegalLinearOpModeAccess() {
+        // A non-linear API.
         val api = EmptyAPI()
 
         assertFailsWith<IllegalLinearOpModeAccess> { api.accessLinearOpMode() }
@@ -79,6 +80,7 @@ internal class APITest {
     @Test
     fun testInitLinearAPIWithoutLinearOpMode() {
         val linearAPI = EmptyLinearAPI()
+        // A non-linear opmode.
         val opMode = EmptyOpMode()
 
         assertFailsWith<InitLinearAPIWithoutLinearOpMode> { linearAPI.init(opMode) }

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
@@ -5,23 +5,33 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class APITest {
+    private open class EmptyAPI : API() {
+        fun accessOpMode() = this.opMode
+
+        fun accessLinearOpMode() = this.linearOpMode
+    }
+
+    private class EmptyLinearAPI : EmptyAPI() {
+        override val isLinear = true
+    }
+
+    private class EmptyOpMode : OpMode() {
+        override fun init() {}
+
+        override fun loop() {}
+    }
+
     @Test
     fun testAPINotInitialized() {
-        val api = object : API() {
-            fun accessOpMode() = this.opMode
-        }
+        val api = EmptyAPI()
 
         assertFailsWith<APINotInitialized> { api.accessOpMode() }
     }
 
     @Test
     fun testInitAPIMoreThanOnce() {
-        val opMode = object : OpMode() {
-            override fun init() {}
-            override fun loop() {}
-        }
-
-        val api = object : API() {}
+        val api = EmptyAPI()
+        val opMode = EmptyOpMode()
 
         // Initialize API once.
         api.init(opMode)
@@ -34,23 +44,15 @@ class APITest {
 
     @Test
     fun testIllegalLinearOpModeAccess() {
-        val api = object : API() {
-            fun accessLinearOpMode() = this.linearOpMode
-        }
+        val api = EmptyAPI()
 
         assertFailsWith<IllegalLinearOpModeAccess> { api.accessLinearOpMode() }
     }
 
     @Test
     fun testInitLinearAPIWithoutLinearOpMode() {
-        val opMode = object : OpMode() {
-            override fun init() {}
-            override fun loop() {}
-        }
-
-        val api = object : API() {
-            override val isLinear = true
-        }
+        val api = EmptyLinearAPI()
+        val opMode = EmptyOpMode()
 
         assertFailsWith<InitLinearAPIWithoutLinearOpMode> { api.init(opMode) }
     }

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
@@ -1,0 +1,57 @@
+package org.firstinspires.ftc.teamcode.core
+
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class APITest {
+    @Test
+    fun testAPINotInitialized() {
+        val api = object : API() {
+            fun accessOpMode() = this.opMode
+        }
+
+        assertFailsWith<APINotInitialized> { api.accessOpMode() }
+    }
+
+    @Test
+    fun testInitAPIMoreThanOnce() {
+        val opMode = object : OpMode() {
+            override fun init() {}
+            override fun loop() {}
+        }
+
+        val api = object : API() {}
+
+        // Initialize API once.
+        api.init(opMode)
+
+        assertFailsWith<InitAPIMoreThanOnce> {
+            // Initialize API twice.
+            api.init(opMode)
+        }
+    }
+
+    @Test
+    fun testIllegalLinearOpModeAccess() {
+        val api = object : API() {
+            fun accessLinearOpMode() = this.linearOpMode
+        }
+
+        assertFailsWith<IllegalLinearOpModeAccess> { api.accessLinearOpMode() }
+    }
+
+    @Test
+    fun testInitLinearAPIWithoutLinearOpMode() {
+        val opMode = object : OpMode() {
+            override fun init() {}
+            override fun loop() {}
+        }
+
+        val api = object : API() {
+            override val isLinear = true
+        }
+
+        assertFailsWith<InitLinearAPIWithoutLinearOpMode> { api.init(opMode) }
+    }
+}


### PR DESCRIPTION
Part of #23, follow-up of #13.

This adds unit tests for all of the functionality of the `API` class to make sure it is working properly.