### PR TITLE
`Input` API (AKA `GamepadEx`)

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/input/Button.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/input/Button.kt
@@ -1,0 +1,52 @@
+package org.firstinspires.ftc.teamcode.api.input
+
+import com.qualcomm.robotcore.hardware.Gamepad
+
+/** Represents a button on a [Gamepad]. */
+enum class Button {
+    DPadUp {
+        override fun pressed(gamepad: Gamepad) = gamepad.dpad_up
+    },
+    DPadDown {
+        override fun pressed(gamepad: Gamepad) = gamepad.dpad_down
+    },
+    DPadLeft {
+        override fun pressed(gamepad: Gamepad) = gamepad.dpad_left
+    },
+    DPadRight {
+        override fun pressed(gamepad: Gamepad) = gamepad.dpad_right
+    },
+    A {
+        override fun pressed(gamepad: Gamepad) = gamepad.a
+    },
+    B {
+        override fun pressed(gamepad: Gamepad) = gamepad.b
+    },
+    X {
+        override fun pressed(gamepad: Gamepad) = gamepad.x
+    },
+    Y {
+        override fun pressed(gamepad: Gamepad) = gamepad.y
+    },
+    Start {
+        override fun pressed(gamepad: Gamepad) = gamepad.start
+    },
+    Back {
+        override fun pressed(gamepad: Gamepad) = gamepad.back
+    },
+    LeftBumper {
+        override fun pressed(gamepad: Gamepad) = gamepad.left_bumper
+    },
+    RightBumper {
+        override fun pressed(gamepad: Gamepad) = gamepad.right_bumper
+    },
+    LeftStickButton {
+        override fun pressed(gamepad: Gamepad) = gamepad.left_stick_button
+    },
+    RightStickButton {
+        override fun pressed(gamepad: Gamepad) = gamepad.right_stick_button
+    },
+    ;
+
+    abstract fun pressed(gamepad: Gamepad): Boolean
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/input/GamepadEx.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/input/GamepadEx.kt
@@ -1,0 +1,84 @@
+package org.firstinspires.ftc.teamcode.api.input
+
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+import com.qualcomm.robotcore.hardware.Gamepad
+
+/**
+ * An advanced version of [Gamepad] that detects immediate presses and releases, useful for advanced
+ * controls and user-interfaces.
+ *
+ * This needs to be updatedd repeatedly by calling [update] to detect new input.
+ *
+ * Usually you do not want to create this yourself. Instead, go through the [Input] API.
+ */
+class GamepadEx(private val number: GamepadNumber) {
+    /** Represents which of the 2 possible gamepads this [GamepadEx] is associated with. */
+    enum class GamepadNumber {
+        Gamepad1,
+        Gamepad2,
+    }
+
+    // This is where the main state is kept. We use a set here because is de-duplicates values.
+    // (B cannot be pressed twice at the same time!)
+    private val pressed: MutableSet<Button> = mutableSetOf()
+    private val justPressed: MutableSet<Button> = mutableSetOf()
+    private val justReleased: MutableSet<Button> = mutableSetOf()
+
+    /**
+     * Returns true if [button] is currently pressed.
+     *
+     * @see update
+     */
+    fun pressed(button: Button): Boolean = button in this.pressed
+
+    /**
+     * Returns true if [button] was pressed this update.
+     *
+     * @see update
+     */
+    fun justPressed(button: Button): Boolean = button in this.justPressed
+
+    /**
+     * Returns true if [button] was released this update.
+     *
+     * @see update
+     */
+    fun justReleased(button: Button): Boolean = button in this.justReleased
+
+    /**
+     * Updates this for new gamepad events.
+     *
+     * You likely want to call this within a loop to react to new button presses and releases.
+     *
+     * @see OpMode.loop
+     * @see OpMode.init_loop
+     * @see LinearOpMode.opModeIsActive
+     * @see LinearOpMode.opModeInInit
+     */
+    fun update(opMode: OpMode) {
+        this.justPressed.clear()
+        this.justReleased.clear()
+
+        val gamepad = when (this.number) {
+            GamepadNumber.Gamepad1 -> opMode.gamepad1
+            GamepadNumber.Gamepad2 -> opMode.gamepad2
+        }
+
+        for (button in Button.entries) {
+            if (button.pressed(gamepad)) {
+                // This button is pressed, so add it to the set. `add()` will return true if the
+                // button did not exist, in which case we also want to add it to `justPressed`.
+                if (this.pressed.add(button)) {
+                    this.justPressed.add(button)
+                }
+            } else {
+                // This button is not pressed, so we remove it from the set. `remove()` returns true
+                // if the button was found to be removed, in which case we add it to `justReleased`.
+                if (this.pressed.remove(button)) {
+                    this.justReleased.add(button)
+                }
+            }
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/input/GamepadEx.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/input/GamepadEx.kt
@@ -1,7 +1,7 @@
 package org.firstinspires.ftc.teamcode.api.input
 
-import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.hardware.Gamepad
 
 /**
@@ -60,10 +60,11 @@ class GamepadEx(private val number: GamepadNumber) {
         this.justPressed.clear()
         this.justReleased.clear()
 
-        val gamepad = when (this.number) {
-            GamepadNumber.Gamepad1 -> opMode.gamepad1
-            GamepadNumber.Gamepad2 -> opMode.gamepad2
-        }
+        val gamepad =
+            when (this.number) {
+                GamepadNumber.Gamepad1 -> opMode.gamepad1
+                GamepadNumber.Gamepad2 -> opMode.gamepad2
+            }
 
         for (button in Button.entries) {
             if (button.pressed(gamepad)) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/input/Input.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/input/Input.kt
@@ -1,0 +1,38 @@
+package org.firstinspires.ftc.teamcode.api.input
+
+import org.firstinspires.ftc.teamcode.core.API
+import org.firstinspires.ftc.teamcode.core.Resettable
+
+object Input : API() {
+    val gamepad1: GamepadEx by Resettable { GamepadEx(GamepadEx.GamepadNumber.Gamepad1) }
+    val gamepad2: GamepadEx by Resettable { GamepadEx(GamepadEx.GamepadNumber.Gamepad2) }
+
+    /**
+     * Returns true if [button] is currently pressed for [gamepad1].
+     *
+     * @see update
+     */
+    fun pressed(button: Button) = this.gamepad1.pressed(button)
+
+    /**
+     * Returns true if [button] was pressed this update for [gamepad1].
+     *
+     * @see update
+     */
+    fun justPressed(button: Button) = this.gamepad1.justPressed(button)
+
+    /**
+     * Returns true if [button] was released this update for [gamepad1].
+     *
+     * @see update
+     */
+    fun justReleased(button: Button) = this.gamepad1.justReleased(button)
+
+    /**
+     * Calls [GamepadEx.update] for both [gamepad1] and [gamepad2].
+     */
+    fun update() {
+        this.gamepad1.update(this.opMode)
+        this.gamepad2.update(this.opMode)
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/Reset.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/Reset.kt
@@ -85,7 +85,7 @@ object ResetListener : OpModeManagerNotifier.Notifications {
         ftcEventLoop.opModeManager.registerListener(this)
     }
 
-    private fun resetAll() {
+    internal fun resetAll() {
         // Call each function in the global set.
         resetFunctions.forEach { it() }
     }

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/Utils.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/Utils.kt
@@ -1,0 +1,13 @@
+package org.firstinspires.ftc.teamcode
+
+import org.firstinspires.ftc.teamcode.core.ResetListener
+
+/**
+ * Calls [ResetListener.resetAll], then runs [func].
+ *
+ * This should be used when testing APIs that require state.
+ */
+fun withReset(func: () -> Unit) {
+    ResetListener.resetAll()
+    func()
+}

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/api/InputTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/api/InputTest.kt
@@ -1,0 +1,169 @@
+package org.firstinspires.ftc.teamcode.api
+
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.hardware.Gamepad
+import org.firstinspires.ftc.teamcode.api.input.Button
+import org.firstinspires.ftc.teamcode.api.input.GamepadEx
+import org.firstinspires.ftc.teamcode.api.input.Input
+import org.firstinspires.ftc.teamcode.withReset
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class InputTest {
+    private class EmptyOpMode : OpMode() {
+        init {
+            this.gamepad1 = Gamepad()
+            this.gamepad2 = Gamepad()
+        }
+
+        override fun init() {}
+
+        override fun loop() {}
+    }
+
+    @Test
+    fun testPressed() {
+        val opMode = EmptyOpMode()
+        val gamepadEx = GamepadEx(GamepadEx.GamepadNumber.Gamepad1)
+
+        // Press X and update.
+        opMode.gamepad1.x = true
+        gamepadEx.update(opMode)
+
+        assertTrue(gamepadEx.pressed(Button.X))
+
+        // Hold X and update.
+        gamepadEx.update(opMode)
+
+        assertTrue(gamepadEx.pressed(Button.X))
+
+        // Release X and update.
+        opMode.gamepad1.x = false
+        gamepadEx.update(opMode)
+
+        assertFalse(gamepadEx.pressed(Button.X))
+    }
+
+    @Test
+    fun testJustPressed() {
+        val opMode = EmptyOpMode()
+        val gamepadEx = GamepadEx(GamepadEx.GamepadNumber.Gamepad1)
+
+        // Press Y and update.
+        opMode.gamepad1.y = true
+        gamepadEx.update(opMode)
+
+        assertTrue(gamepadEx.justPressed(Button.Y))
+
+        // Hold Y and update.
+        gamepadEx.update(opMode)
+
+        assertFalse(gamepadEx.justPressed(Button.Y))
+
+        // Release Y and update.
+        opMode.gamepad1.y = false
+        gamepadEx.update(opMode)
+
+        assertFalse(gamepadEx.justPressed(Button.Y))
+    }
+
+    @Test
+    fun testJustReleased() {
+        val opMode = EmptyOpMode()
+        val gamepadEx = GamepadEx(GamepadEx.GamepadNumber.Gamepad1)
+
+        // Press A and update.
+        opMode.gamepad1.a = true
+        gamepadEx.update(opMode)
+
+        assertFalse(gamepadEx.justReleased(Button.A))
+
+        // Release A and update.
+        opMode.gamepad1.a = false
+        gamepadEx.update(opMode)
+
+        assertTrue(gamepadEx.justReleased(Button.A))
+
+        // Keep A released and update.
+        gamepadEx.update(opMode)
+
+        assertFalse(gamepadEx.justReleased(Button.A))
+    }
+
+    @Test
+    fun testGamepad2() {
+        val opMode = EmptyOpMode()
+        val gamepadEx1 = GamepadEx(GamepadEx.GamepadNumber.Gamepad1)
+        val gamepadEx2 = GamepadEx(GamepadEx.GamepadNumber.Gamepad2)
+
+        // Press B on Gamepad 1.
+        opMode.gamepad1.b = true
+        gamepadEx1.update(opMode)
+        gamepadEx2.update(opMode)
+
+        assertTrue(gamepadEx1.pressed(Button.B))
+        assertFalse(gamepadEx2.pressed(Button.B))
+
+        // Press B on Gamepad 2, hold B on Gamepad 1.
+        opMode.gamepad2.b = true
+        gamepadEx1.update(opMode)
+        gamepadEx2.update(opMode)
+
+        assertTrue(gamepadEx1.pressed(Button.B))
+        assertTrue(gamepadEx2.pressed(Button.B))
+
+        // Release B on both gamepads.
+        opMode.gamepad1.b = false
+        opMode.gamepad2.b = false
+        gamepadEx1.update(opMode)
+        gamepadEx2.update(opMode)
+
+        assertFalse(gamepadEx1.pressed(Button.B))
+        assertFalse(gamepadEx2.pressed(Button.B))
+    }
+
+    @Test
+    fun testAPIShortcuts() = withReset {
+        val opMode = EmptyOpMode()
+        Input.init(opMode)
+
+        opMode.gamepad1.dpad_up = true
+        Input.update()
+
+        assertTrue(Input.pressed(Button.DPadUp))
+        assertTrue(Input.justPressed(Button.DPadUp))
+
+        opMode.gamepad1.dpad_up = false
+        Input.update()
+
+        assertFalse(Input.pressed(Button.DPadUp))
+        assertTrue(Input.justReleased(Button.DPadUp))
+    }
+
+    @Test
+    fun testAPIGamepads() = withReset {
+        val opMode = EmptyOpMode()
+        Input.init(opMode)
+
+        val gamepad1 = Input.gamepad1
+        val gamepad2 = Input.gamepad2
+
+        opMode.gamepad1.left_bumper = true
+        opMode.gamepad2.right_bumper = true
+        Input.update()
+
+        assertTrue(gamepad1.pressed(Button.LeftBumper))
+        assertTrue(gamepad2.pressed(Button.RightBumper))
+    }
+
+    @Test
+    fun testButtonPressed() {
+        val gamepad = Gamepad()
+        val button = Button.LeftStickButton
+
+        gamepad.left_stick_button = true
+
+        assertTrue(button.pressed(gamepad))
+    }
+}

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/api/InputTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/api/InputTest.kt
@@ -124,38 +124,40 @@ internal class InputTest {
     }
 
     @Test
-    fun testAPIShortcuts() = withReset {
-        val opMode = EmptyOpMode()
-        Input.init(opMode)
+    fun testAPIShortcuts() =
+        withReset {
+            val opMode = EmptyOpMode()
+            Input.init(opMode)
 
-        opMode.gamepad1.dpad_up = true
-        Input.update()
+            opMode.gamepad1.dpad_up = true
+            Input.update()
 
-        assertTrue(Input.pressed(Button.DPadUp))
-        assertTrue(Input.justPressed(Button.DPadUp))
+            assertTrue(Input.pressed(Button.DPadUp))
+            assertTrue(Input.justPressed(Button.DPadUp))
 
-        opMode.gamepad1.dpad_up = false
-        Input.update()
+            opMode.gamepad1.dpad_up = false
+            Input.update()
 
-        assertFalse(Input.pressed(Button.DPadUp))
-        assertTrue(Input.justReleased(Button.DPadUp))
-    }
+            assertFalse(Input.pressed(Button.DPadUp))
+            assertTrue(Input.justReleased(Button.DPadUp))
+        }
 
     @Test
-    fun testAPIGamepads() = withReset {
-        val opMode = EmptyOpMode()
-        Input.init(opMode)
+    fun testAPIGamepads() =
+        withReset {
+            val opMode = EmptyOpMode()
+            Input.init(opMode)
 
-        val gamepad1 = Input.gamepad1
-        val gamepad2 = Input.gamepad2
+            val gamepad1 = Input.gamepad1
+            val gamepad2 = Input.gamepad2
 
-        opMode.gamepad1.left_bumper = true
-        opMode.gamepad2.right_bumper = true
-        Input.update()
+            opMode.gamepad1.left_bumper = true
+            opMode.gamepad2.right_bumper = true
+            Input.update()
 
-        assertTrue(gamepad1.pressed(Button.LeftBumper))
-        assertTrue(gamepad2.pressed(Button.RightBumper))
-    }
+            assertTrue(gamepad1.pressed(Button.LeftBumper))
+            assertTrue(gamepad2.pressed(Button.RightBumper))
+        }
 
     @Test
     fun testButtonPressed() {


### PR DESCRIPTION
Closes #31!

This adds the `Input` API, which can be used for advanced input use-cases. Normally, you can just check if a button is pressed or not by getting `opMode.gamepad1.a` or `opMode.gamepad1.x`. This enhances that functionality by also detecting _presses_ and _releases_. It works by calling the `update()` function within the runloop, and detecting the difference in button presses.

This is inspired by last year's `GamepadEx` API, but has a few major differences:

1. `Input`: The main API to access these inputs. Provides shortcuts for detecting presses and releases for `gamepad1`.
2. `GamepadEx`: A class that handles the actual change detection. You can access it by getting `Input.gamepad1` or `Input.gamepad2`.
3. `Button`: An enum that represents every single boolean button. (Note that this does not support joystick positions, the trigger buttons, the touchpad, and PS4 aliases.)