### PR TITLE
Voltage API

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Voltage.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Voltage.kt
@@ -1,0 +1,28 @@
+package org.firstinspires.ftc.teamcode.api
+
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.hardware.VoltageSensor
+import org.firstinspires.ftc.teamcode.core.API
+
+/**
+ * An API that enables access to the voltage of the control hub.
+ *
+ * @see get
+ */
+object Voltage : API() {
+    private lateinit var sensor: VoltageSensor
+
+    override fun init(opMode: OpMode) {
+        super.init(opMode)
+
+        // TODO(BD103): Log if amount of voltage sensors != 1.
+
+        // Get the sensor from the list of sensors, since we don't know its name.
+        this.sensor = opMode.hardwareMap.voltageSensor.iterator().next()
+    }
+
+    /**
+     * Returns the current voltage of the control hub.
+     */
+    fun get(): Double = this.sensor.voltage
+}


### PR DESCRIPTION
This adds a small API that enables access to the current voltage of the control hub. Voltage affects the max speed of motors, so we can use this to automatically account for that.

This will be used for the Road Runner `KiwiDrive`.