### PR TITLE
Add a property to detect whether an API is initialized

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/API.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/API.kt
@@ -39,6 +39,14 @@ abstract class API {
         }
 
     /**
+     * Returns true if [init] has been called for this opmode.
+     *
+     * Use this to detect if API can be used, or if it needs to be initialized.
+     */
+    val isInit: Boolean
+        get() = this.nullableOpMode.isNotNull()
+
+    /**
      * Defines whether this API requires features from [LinearOpMode].
      *
      * If set to true, [init] can only be called from within a [LinearOpMode]. This is useful if you

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/core/APITest.kt
@@ -4,7 +4,9 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 internal class APITest {
     private open class EmptyAPI : API() {
@@ -34,6 +36,7 @@ internal class APITest {
 
         api.init(opMode)
 
+        assertTrue(api.isInit)
         assertSame(opMode, api.accessOpMode())
     }
 
@@ -52,6 +55,7 @@ internal class APITest {
     fun testAPINotInitialized() {
         val api = EmptyAPI()
 
+        assertFalse(api.isInit)
         assertFailsWith<APINotInitialized> { api.accessOpMode() }
     }
 


### PR DESCRIPTION
Occasionally you may write a class that depends on an API, but is not an API itself so it cannot use the built-in dependencies system. This PR adds the boolean property `API.isInit`, which returns true if the API has been initialized.

I plan to use this as part of #26, so you don't try to use a `KiwiDrive` without initialized `TriWheels` first.