### PR TITLE
`TriWheels` localization

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -127,10 +127,11 @@ object TriWheels : API() {
     fun compute(polar: Polar2d) = compute(polar.theta, polar.radius)
 
     fun inverse(ratio: Triple<Double, Double, Double>): Vector2d {
-        val r = Polar2d(RED_ANGLE + PI_2, ratio.first).toCartesian()
-        val g = Polar2d(GREEN_ANGLE + PI_2, ratio.second).toCartesian()
-        val b = Polar2d(BLUE_ANGLE + PI_2, ratio.third).toCartesian()
+        val r = Polar2d(RED_ANGLE - PI_2, ratio.first).toCartesian()
+        val g = Polar2d(GREEN_ANGLE - PI_2, ratio.second).toCartesian()
+        val b = Polar2d(BLUE_ANGLE - PI_2, ratio.third).toCartesian()
 
-        return r + g + b
+        // For some reason there's a coefficient of 1.5 that needs to be divided out.
+        return (r + g + b) / 1.5
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -72,6 +72,14 @@ object TriWheels : API() {
         power(r + rotation, g + rotation, b + rotation)
     }
 
+    fun drive(
+        polar: Polar2d,
+        rotation: Double = 0.0,
+    ) {
+        val (r, g, b) = compute(polar)
+        power(r + rotation, g + rotation, b + rotation)
+    }
+
     /**
      * Makes all 3 wheels stop.
      *

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -26,6 +26,8 @@ object TriWheels : API() {
     private const val GREEN_ANGLE: Double = PI * (11.0 / 6.0)
     private const val BLUE_ANGLE: Double = PI * (7.0 / 6.0)
 
+    private const val PI_2: Double = PI / 2.0
+
     override fun init(opMode: OpMode) {
         super.init(opMode)
 
@@ -125,9 +127,9 @@ object TriWheels : API() {
     fun compute(polar: Polar2d) = compute(polar.theta, polar.radius)
 
     fun inverse(ratio: Triple<Double, Double, Double>): Vector2d {
-        val r = Polar2d(RED_ANGLE, ratio.first).toCartesian()
-        val g = Polar2d(GREEN_ANGLE, ratio.second).toCartesian()
-        val b = Polar2d(BLUE_ANGLE, ratio.third).toCartesian()
+        val r = Polar2d(RED_ANGLE + PI_2, ratio.first).toCartesian()
+        val g = Polar2d(GREEN_ANGLE + PI_2, ratio.second).toCartesian()
+        val b = Polar2d(BLUE_ANGLE + PI_2, ratio.third).toCartesian()
 
         return r + g + b
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -65,8 +65,8 @@ object TriWheels : API() {
         magnitude: Double,
         rotation: Double = 0.0,
     ) {
-        val (r, g, b) = wheelRatio(radians, magnitude, rotation)
-        power(r, g, b)
+        val (r, g, b) = compute(radians, magnitude)
+        power(r + rotation, g + rotation, b + rotation)
     }
 
     /**
@@ -104,22 +104,19 @@ object TriWheels : API() {
     }
 
     /**
-     * Returns the ratio of how much each wheel should spin for given angle in [radians].
-     *
-     * The [magnitude] can be used to scale the ration (make it faster / larger), and the [rotation]
-     * can be used to add a constant offset (to make it spin while traveling in a direction).
+     * Returns the ratio of how much each wheel should spin for given angle in [radians] and
+     * strength in [magnitude].
      *
      * For a visual demonstration of what this is doing, see
      * [this Desmos graph](https://www.desmos.com/geometry/b6h0f7fjls).
      */
-    private fun wheelRatio(
+    fun compute(
         radians: Double,
         magnitude: Double,
-        rotation: Double = 0.0,
     ): Triple<Double, Double, Double> =
         Triple(
-            magnitude * sin(RED_ANGLE - radians) + rotation,
-            magnitude * sin(GREEN_ANGLE - radians) + rotation,
-            magnitude * sin(BLUE_ANGLE - radians) + rotation,
+            magnitude * sin(RED_ANGLE - radians),
+            magnitude * sin(GREEN_ANGLE - radians),
+            magnitude * sin(BLUE_ANGLE - radians),
         )
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -6,6 +6,7 @@ import com.qualcomm.robotcore.hardware.DcMotor
 import com.qualcomm.robotcore.hardware.DcMotorEx
 import com.qualcomm.robotcore.hardware.DcMotorSimple
 import org.firstinspires.ftc.teamcode.core.API
+import org.firstinspires.ftc.teamcode.utils.PI_2
 import org.firstinspires.ftc.teamcode.utils.Polar2d
 import kotlin.math.PI
 import kotlin.math.sin
@@ -25,8 +26,6 @@ object TriWheels : API() {
     private const val RED_ANGLE: Double = PI / 2.0
     private const val GREEN_ANGLE: Double = PI * (11.0 / 6.0)
     private const val BLUE_ANGLE: Double = PI * (7.0 / 6.0)
-
-    private const val PI_2: Double = PI / 2.0
 
     override fun init(opMode: OpMode) {
         super.init(opMode)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -1,10 +1,12 @@
 package org.firstinspires.ftc.teamcode.api
 
+import com.acmerobotics.roadrunner.Vector2d
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.hardware.DcMotor
 import com.qualcomm.robotcore.hardware.DcMotorEx
 import com.qualcomm.robotcore.hardware.DcMotorSimple
 import org.firstinspires.ftc.teamcode.core.API
+import org.firstinspires.ftc.teamcode.utils.Polar2d
 import kotlin.math.PI
 import kotlin.math.sin
 
@@ -119,4 +121,14 @@ object TriWheels : API() {
             magnitude * sin(GREEN_ANGLE - radians),
             magnitude * sin(BLUE_ANGLE - radians),
         )
+
+    fun compute(polar: Polar2d) = compute(polar.theta, polar.radius)
+
+    fun inverse(ratio: Triple<Double, Double, Double>): Vector2d {
+        val r = Polar2d(RED_ANGLE, ratio.first).toCartesian()
+        val g = Polar2d(GREEN_ANGLE, ratio.second).toCartesian()
+        val b = Polar2d(BLUE_ANGLE, ratio.third).toCartesian()
+
+        return r + g + b
+    }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/demos/EncoderLocalizationDemo.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/demos/EncoderLocalizationDemo.kt
@@ -1,0 +1,72 @@
+package org.firstinspires.ftc.teamcode.teleop.demos
+
+import com.acmerobotics.dashboard.FtcDashboard
+import com.acmerobotics.dashboard.telemetry.TelemetryPacket
+import com.qualcomm.robotcore.eventloop.opmode.Disabled
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp
+import org.firstinspires.ftc.teamcode.api.TriWheels
+import org.firstinspires.ftc.teamcode.utils.Polar2d
+import kotlin.math.PI
+
+@TeleOp(name = "Encoder Localization Demo", group = "Demo")
+@Disabled
+class EncoderLocalizationDemo : OpMode() {
+    private val driveSpeed = 0.3
+    private val wheelDiameter = 3.8
+    private val ticksPerRevolution = 145.1
+
+    override fun init() {
+        TriWheels.init(this)
+        telemetry.addData("Status", "Initialized")
+    }
+
+    override fun loop() {
+        // Drive robot with left joystick.
+        TriWheels.drive(
+            Polar2d.fromCartesian(gamepad1.left_stick_x.toDouble() * this.driveSpeed, -gamepad1.left_stick_y.toDouble() * this.driveSpeed),
+            0.0,
+        )
+
+        // Reset position to (0, 0) when both bumpers are pressed.
+        if (gamepad1.left_bumper && gamepad1.right_bumper) {
+            TriWheels.stopAndResetMotors()
+        }
+
+        // Find positions of each wheel, converting to distance traveled in inches.
+        val wheelPositions =
+            Triple(
+                this.ticksToInch(TriWheels.red.currentPosition),
+                this.ticksToInch(TriWheels.green.currentPosition),
+                this.ticksToInch(TriWheels.blue.currentPosition),
+            )
+
+        // Find position of the entire robot.
+        val robotPosition = TriWheels.inverse(wheelPositions)
+
+        val packet = TelemetryPacket()
+
+        // Log information to both FTC Dashboard and telemetry.
+        for (f in listOf(packet::put, telemetry::addData)) {
+            f("Red", wheelPositions.first)
+            f("Green", wheelPositions.second)
+            f("Blue", wheelPositions.third)
+
+            f("X", robotPosition.x)
+            f("Y", robotPosition.y)
+        }
+
+        // Draw robot for FTC Dashboard.
+        packet.fieldOverlay().apply {
+            setStroke("#3F51B5")
+            setStrokeWidth(1)
+            strokeCircle(robotPosition.x, robotPosition.y, 9.0)
+        }
+
+        FtcDashboard.getInstance().sendTelemetryPacket(packet)
+
+        telemetry.addData("Status", "Running")
+    }
+
+    private fun ticksToInch(position: Int) = position.toDouble() / this.ticksPerRevolution * this.wheelDiameter * PI
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
@@ -1,0 +1,26 @@
+package org.firstinspires.ftc.teamcode.utils
+
+import com.acmerobotics.roadrunner.Vector2d
+import kotlin.math.absoluteValue
+import kotlin.math.pow
+import kotlin.math.round
+
+/**
+ * Truncates a number a certain number of decimal places.
+ *
+ * This can be useful when comparing two doubles, since floating point operations tend to cause
+ * small amounts of drift.
+ *
+ * For example, `(3.222).truncate(1) == 3.2`. We're truncating to the 1st decimal place, rounding
+ * the rest down. On the other hand, `(0.9999).truncate(3) == 1.0` because the 4th 9 rounds up.
+ */
+fun Double.truncate(places: Int): Double {
+    val k = 10.0.pow(places)
+    return round(this * k) / k
+}
+
+/** Returns the absolute value of a [Vector2d]. */
+fun Vector2d.abs() = Vector2d(this.x.absoluteValue, this.y.absoluteValue)
+
+/** Applies function [f] to both [Vector2d.x] and [Vector2d.y], returning the result. */
+inline fun Vector2d.map(f: (Double) -> Double) = Vector2d(f(this.x), f(this.y))

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
@@ -1,8 +1,12 @@
 package org.firstinspires.ftc.teamcode.utils
 
 import com.acmerobotics.roadrunner.Vector2d
+import kotlin.math.PI
 import kotlin.math.pow
 import kotlin.math.round
+
+/** PI / 2 */
+const val PI_2: Double = PI / 2.0
 
 /**
  * Rounds a number to a certain number of decimal places.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
@@ -1,7 +1,6 @@
 package org.firstinspires.ftc.teamcode.utils
 
 import com.acmerobotics.roadrunner.Vector2d
-import kotlin.math.absoluteValue
 import kotlin.math.pow
 import kotlin.math.round
 
@@ -18,9 +17,6 @@ fun Double.truncate(places: Int): Double {
     val k = 10.0.pow(places)
     return round(this * k) / k
 }
-
-/** Returns the absolute value of a [Vector2d]. */
-fun Vector2d.abs() = Vector2d(this.x.absoluteValue, this.y.absoluteValue)
 
 /** Applies function [f] to both [Vector2d.x] and [Vector2d.y], returning the result. */
 inline fun Vector2d.map(f: (Double) -> Double) = Vector2d(f(this.x), f(this.y))

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
@@ -5,15 +5,15 @@ import kotlin.math.pow
 import kotlin.math.round
 
 /**
- * Truncates a number a certain number of decimal places.
+ * Rounds a number to a certain number of decimal places.
  *
  * This can be useful when comparing two doubles, since floating point operations tend to cause
  * small amounts of drift.
  *
- * For example, `(3.222).truncate(1) == 3.2`. We're truncating to the 1st decimal place, rounding
- * the rest down. On the other hand, `(0.9999).truncate(3) == 1.0` because the 4th 9 rounds up.
+ * For example, `(3.222).roundDecimal(1) == 3.2`. We're truncating to the 1st decimal place, rounding
+ * the rest down. On the other hand, `(0.9999).roundDecimal(3) == 1.0` because the 4th 9 rounds up.
  */
-fun Double.truncate(places: Int): Double {
+fun Double.roundDecimal(places: Int): Double {
     val k = 10.0.pow(places)
     return round(this * k) / k
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Polar2d.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Polar2d.kt
@@ -1,0 +1,45 @@
+package org.firstinspires.ftc.teamcode.utils
+
+import com.acmerobotics.roadrunner.Vector2d
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+
+/**
+ * Represents a coordinate in the
+ * [polar coordinate system](https://en.wikipedia.org/wiki/Polar_coordinate_system).
+ *
+ * [theta] is the relative angle from 0 in radians on the unit circle. (A theta of 0 points to the
+ * right, not up.) [radius] is the distance from the center, used to represent strength or
+ * magnitude.
+ *
+ * For a alternative to this that uses the cartesian coordinate system (x, y), see [Vector2d].
+ */
+data class Polar2d(val theta: Double, val radius: Double) {
+    companion object {
+        /** Converts cartesian coordinates into polar coordinates. */
+        fun fromCartesian(
+            x: Double,
+            y: Double,
+        ): Polar2d {
+            // Inverse tangent to find the angle, except it special-cases specific circumstances.
+            val theta = atan2(y, x)
+
+            // Calculate the hypotenuse (distance) using sqrt(x^2 + y^2).
+            val radius = hypot(x, y)
+
+            return Polar2d(theta, radius)
+        }
+
+        /** Converts cartesian coordinates into polar coordinates. */
+        fun fromCartesian(cartesian: Vector2d): Polar2d = fromCartesian(cartesian.x, cartesian.y)
+    }
+
+    /** Returns the cartesian form of these polar coordinates. */
+    fun toCartesian(): Vector2d =
+        Vector2d(
+            this.radius * cos(this.theta),
+            this.radius * sin(this.theta),
+        )
+}

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/api/TriWheelsTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/api/TriWheelsTest.kt
@@ -3,7 +3,7 @@ package org.firstinspires.ftc.teamcode.api
 import com.acmerobotics.roadrunner.Vector2d
 import org.firstinspires.ftc.teamcode.utils.Polar2d
 import org.firstinspires.ftc.teamcode.utils.map
-import org.firstinspires.ftc.teamcode.utils.truncate
+import org.firstinspires.ftc.teamcode.utils.roundDecimal
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -27,6 +27,6 @@ internal class TriWheelsTest {
         val ratio = TriWheels.compute(Polar2d.fromCartesian(expected))
         val actual = TriWheels.inverse(ratio)
 
-        assertEquals(expected, actual.map { it.truncate(4) })
+        assertEquals(expected, actual.map { it.roundDecimal(4) })
     }
 }

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/api/TriWheelsTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/api/TriWheelsTest.kt
@@ -1,0 +1,32 @@
+package org.firstinspires.ftc.teamcode.api
+
+import com.acmerobotics.roadrunner.Vector2d
+import org.firstinspires.ftc.teamcode.utils.Polar2d
+import org.firstinspires.ftc.teamcode.utils.map
+import org.firstinspires.ftc.teamcode.utils.truncate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class TriWheelsTest {
+    @Test
+    fun testInverseZero() {
+        val expected = Vector2d(0.0, 0.0)
+
+        // Convert to wheel ratios and back, converting -0.0 to +0.0.
+        val ratio = TriWheels.compute(Polar2d.fromCartesian(expected))
+        val actual = TriWheels.inverse(ratio)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testInverse() {
+        val expected = Vector2d(-1.0, 1.5)
+
+        // Convert to wheel ratios and back.
+        val ratio = TriWheels.compute(Polar2d.fromCartesian(expected))
+        val actual = TriWheels.inverse(ratio)
+
+        assertEquals(expected, actual.map { it.truncate(4) })
+    }
+}

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
@@ -6,15 +6,15 @@ import kotlin.test.assertEquals
 
 internal class MathTest {
     @Test
-    fun testDoubleTruncate() {
+    fun testDoubleRoundDecimal() {
         val a = 0.9999999999
-        assertEquals(1.0, a.truncate(3))
+        assertEquals(1.0, a.roundDecimal(3))
 
         val b = 2.1111111111
-        assertEquals(2.111, b.truncate(3))
+        assertEquals(2.111, b.roundDecimal(3))
 
         val c = 1.0
-        assertEquals(1.0, c.truncate(3))
+        assertEquals(1.0, c.roundDecimal(3))
     }
 
     @Test

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
@@ -18,14 +18,6 @@ internal class MathTest {
     }
 
     @Test
-    fun testVector2dAbs() {
-        val expected = Vector2d(2.0, 1.0)
-        val actual = Vector2d(-2.0, -1.0).abs()
-
-        assertEquals(expected, actual)
-    }
-
-    @Test
     fun testVector2dMap() {
         val expected = Vector2d(4.0, 3.0)
         val actual = Vector2d(2.0, 1.5).map { it * 2.0 }

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
@@ -1,0 +1,35 @@
+package org.firstinspires.ftc.teamcode.utils
+
+import com.acmerobotics.roadrunner.Vector2d
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class MathTest {
+    @Test
+    fun testDoubleTruncate() {
+        val a = 0.9999999999
+        assertEquals(1.0, a.truncate(3))
+
+        val b = 2.1111111111
+        assertEquals(2.111, b.truncate(3))
+
+        val c = 1.0
+        assertEquals(1.0, c.truncate(3))
+    }
+
+    @Test
+    fun testVector2dAbs() {
+        val expected = Vector2d(2.0, 1.0)
+        val actual = Vector2d(-2.0, -1.0).abs()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testVector2dMap() {
+        val expected = Vector2d(4.0, 3.0)
+        val actual = Vector2d(2.0, 1.5).map { it * 2.0 }
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
This adds the ability to find the position of the robot given the encoder values of all 3 wheels.

- Renamed `TriWheels.wheelRatio` to `compute`, made it public, and removed the `rotation` argument.
- Created the `TriWheels.inverse` method, which finds the inverse of `compute`.
- Created `Polar2d` to represent polar coordinates. It complements the Cartesian form, `Vector2d`.
- Created several math utilities.
- Added unit tests for all features above.
- Created a demo of using localization.