### PR TITLE
Bump Appcompat dependency to 1.3.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ ftcCenterStageAssets = "1.0.0"
 # FTC associated libraries.
 tensorflowLiteTaskVision = "0.4.3"
 tensorflowLite = "2.12.0"
-androidxAppCompat = "1.2.0"
+androidxAppCompat = "1.3.1"
 
 # FTC Dashboard.
 ftcDashboard = "0.4.15"


### PR DESCRIPTION
This includes a few bug fixes and features for one of our dependencies. We don't directly use it, but FTC Robot Controller does.

Even though the latest version is 1.7.0, we can only update to 1.3.1 because 1.4.0 updates the minimum required Android version. I'll investigate updating this in the future.

To test this, just build it locally. Nothing should change :)