### PR TITLE
`Polar2dDual` and `DualNum.atan()`

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Math.kt
@@ -1,5 +1,6 @@
 package org.firstinspires.ftc.teamcode.utils
 
+import com.acmerobotics.roadrunner.DualNum
 import com.acmerobotics.roadrunner.Vector2d
 import kotlin.math.PI
 import kotlin.math.pow
@@ -24,3 +25,48 @@ fun Double.roundDecimal(places: Int): Double {
 
 /** Applies function [f] to both [Vector2d.x] and [Vector2d.y], returning the result. */
 inline fun Vector2d.map(f: (Double) -> Double) = Vector2d(f(this.x), f(this.y))
+
+/** Returns the inverse tangent of a dual number. */
+fun <Param> DualNum<Param>.atan(): DualNum<Param> {
+    // Please see https://github.com/BotsBurgh/BOTSBURGH-FTC-2024-25/wiki/On-dual-numbers for an
+    // explanation of the code, and a guide to create your own.
+
+    val x = this.values().toDoubleArray()
+    val y = DoubleArray(x.size)
+
+    if (y.isEmpty()) return y.toDual()
+
+    // Constant value
+    y[0] = kotlin.math.atan(x[0])
+    if (y.size == 1) return y.toDual()
+
+    // First derivative
+    val firstDeriv = 1 / (x[0].squared() + 1)
+    y[1] = firstDeriv * x[1]
+    if (y.size == 2) return y.toDual()
+
+    // Second derivative
+    val secondDeriv = (-2 * x[0]) / (x[0].squared() + 1).squared()
+    y[2] = secondDeriv * x[1] + firstDeriv * x[2]
+    if (y.size == 3) return y.toDual()
+
+    // Third derivative
+    val thirdDeriv = (6 * x[0].squared() - 2) / (x[0].squared() + 1).cubed()
+    y[3] = thirdDeriv * x[1] + secondDeriv * x[2] + secondDeriv * x[2] + firstDeriv * x[3]
+
+    return y.toDual()
+}
+
+/**
+ * Converts a [DoubleArray] to a [DualNum].
+ *
+ * This is a temporary method until
+ * [road-runner#108](https://github.com/acmerobotics/road-runner/pull/108) is released.
+ */
+private fun <Param> DoubleArray.toDual() = DualNum<Param>(this.toList())
+
+/** Squares a number `x^2`. */
+private fun Double.squared() = this * this
+
+/** Cubes a number `x^3`. */
+private fun Double.cubed() = this * this * this

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Polar2d.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Polar2d.kt
@@ -1,6 +1,8 @@
 package org.firstinspires.ftc.teamcode.utils
 
+import com.acmerobotics.roadrunner.DualNum
 import com.acmerobotics.roadrunner.Vector2d
+import com.acmerobotics.roadrunner.Vector2dDual
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.hypot
@@ -37,9 +39,39 @@ data class Polar2d(val theta: Double, val radius: Double) {
     }
 
     /** Returns the cartesian form of these polar coordinates. */
-    fun toCartesian(): Vector2d =
+    fun toCartesian() =
         Vector2d(
             this.radius * cos(this.theta),
             this.radius * sin(this.theta),
         )
+}
+
+/** The dual number variant of [Polar2d]. */
+data class Polar2dDual<Param>(val theta: DualNum<Param>, val radius: DualNum<Param>) {
+    companion object {
+        /** Creates a new [Polar2dDual] from a constant [Polar2d] and a size. */
+        fun <Param> constant(
+            p: Polar2d,
+            n: Int,
+        ) = Polar2dDual<Param>(DualNum.constant(p.theta, n), DualNum.constant(p.radius, n))
+
+        fun <Param> fromCartesian(v: Vector2dDual<Param>): Polar2dDual<Param> {
+            val theta = TODO("Inverse tangent `DualNum`.")
+
+            // Calculate the hypotenuse.
+            val radius = v.x * v.x + v.y * v.y
+
+            return Polar2dDual(theta, radius)
+        }
+    }
+
+    /** Returns the cartesian form of these polar coordinates. */
+    fun toCartesian() =
+        Vector2dDual(
+            this.radius * this.theta.cos(),
+            this.radius * this.theta.sin(),
+        )
+
+    /** Returns the value of this polar coordinate. */
+    fun value() = Polar2d(this.theta.value(), this.radius.value())
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Polar2d.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Polar2d.kt
@@ -56,7 +56,8 @@ data class Polar2dDual<Param>(val theta: DualNum<Param>, val radius: DualNum<Par
         ) = Polar2dDual<Param>(DualNum.constant(p.theta, n), DualNum.constant(p.radius, n))
 
         fun <Param> fromCartesian(v: Vector2dDual<Param>): Polar2dDual<Param> {
-            val theta = TODO("Inverse tangent `DualNum`.")
+            // Calculate the slope.
+            val theta = v.atan2()
 
             // Calculate the hypotenuse.
             val radius = v.x * v.x + v.y * v.y

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
@@ -1,9 +1,11 @@
 package org.firstinspires.ftc.teamcode.utils
 
+import com.acmerobotics.roadrunner.DualNum
 import com.acmerobotics.roadrunner.Time
 import com.acmerobotics.roadrunner.Vector2d
 import com.acmerobotics.roadrunner.Vector2dDual
 import kotlin.math.PI
+import kotlin.math.atan
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -27,6 +29,19 @@ internal class MathTest {
         val actual = Vector2d(2.0, 1.5).map { it * 2.0 }
 
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDualAtanConsistency() {
+        val input = 7.5
+
+        val constantDual = DualNum.constant<Time>(input, 4)
+        val variableDual = DualNum.variable<Time>(input, 4)
+
+        // Test that at least the value implementation is correct, even if we can't easily test the
+        // derivatives.
+        assertEquals(atan(input), constantDual.atan().value())
+        assertEquals(atan(input), variableDual.atan().value())
     }
 
     // Derived from https://github.com/JetBrains/kotlin/blob/58392ba3f3f3e50891c91539d5c586ff4600743f/kotlin-native/runtime/test/numbers/MathTest.kt#L51.

--- a/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
+++ b/TeamCode/src/test/kotlin/org/firstinspires/ftc/teamcode/utils/MathTest.kt
@@ -1,8 +1,12 @@
 package org.firstinspires.ftc.teamcode.utils
 
+import com.acmerobotics.roadrunner.Time
 import com.acmerobotics.roadrunner.Vector2d
+import com.acmerobotics.roadrunner.Vector2dDual
+import kotlin.math.PI
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class MathTest {
     @Test
@@ -23,5 +27,33 @@ internal class MathTest {
         val actual = Vector2d(2.0, 1.5).map { it * 2.0 }
 
         assertEquals(expected, actual)
+    }
+
+    // Derived from https://github.com/JetBrains/kotlin/blob/58392ba3f3f3e50891c91539d5c586ff4600743f/kotlin-native/runtime/test/numbers/MathTest.kt#L51.
+    @Test
+    fun testAtan2SpecialCases() {
+        // Creates a dual vector, calculates inverse tangent, then returns the value.
+        fun atan2Dual(
+            y: Double,
+            x: Double,
+        ) = Vector2dDual.constant<Time>(Vector2d(x, y), 4).atan2().value()
+
+        assertEquals(0.0, atan2Dual(0.0, 0.0))
+
+        assertEquals(0.0, atan2Dual(0.0, 1.0))
+        assertEquals(PI, atan2Dual(0.0, -1.0))
+        assertEquals(-0.0, atan2Dual(-0.0, 1.0))
+        assertEquals(-PI, atan2Dual(-0.0, -1.0))
+
+        // In the original test suite, edge cases for infinity were tested here. They have been
+        // skipped, since our implementation for `atan2()` does not support infinity.
+
+        assertEquals(PI / 2, atan2Dual(1.0, 0.0))
+        assertEquals(-PI / 2, atan2Dual(-1.0, 0.0))
+        assertEquals(PI / 2, atan2Dual(Double.POSITIVE_INFINITY, 1.0))
+        assertEquals(-PI / 2, atan2Dual(Double.NEGATIVE_INFINITY, 1.0))
+
+        assertTrue(atan2Dual(Double.NaN, 1.0).isNaN())
+        assertTrue(atan2Dual(1.0, Double.NaN).isNaN())
     }
 }


### PR DESCRIPTION
This PR adds the `Polar2dDual` class, which will be used with Road Runner to calculate the position of the robot based on how far the wheels have rotated. (`TriWheels.inverse()`, but it uses dual numbers.)

Because `Polar2dDual` requires converting to and from `Vector2dDual`, I have also implemented `atan()` (inverse tangent) for `DualNum` and a corresponding `atan2()` for `Vector2dDual`.

For more information on what dual numbers are, see [On dual numbers](https://github.com/BotsBurgh/BOTSBURGH-FTC-2024-25/wiki/On-dual-numbers).