### PR TITLE
Kiwi Kinematics

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/TriWheels.kt
@@ -23,9 +23,9 @@ object TriWheels : API() {
         private set
 
     // The angles of each wheel in radians, where red is forward.
-    private const val RED_ANGLE: Double = PI / 2.0
-    private const val GREEN_ANGLE: Double = PI * (11.0 / 6.0)
-    private const val BLUE_ANGLE: Double = PI * (7.0 / 6.0)
+    const val RED_ANGLE: Double = PI / 2.0
+    const val GREEN_ANGLE: Double = PI * (11.0 / 6.0)
+    const val BLUE_ANGLE: Double = PI * (7.0 / 6.0)
 
     override fun init(opMode: OpMode) {
         super.init(opMode)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
@@ -1,13 +1,18 @@
 package org.firstinspires.ftc.teamcode.api.roadrunner
 
+import com.acmerobotics.roadrunner.Arclength
 import com.acmerobotics.roadrunner.DualNum
+import com.acmerobotics.roadrunner.Pose2dDual
+import com.acmerobotics.roadrunner.PosePath
 import com.acmerobotics.roadrunner.PoseVelocity2dDual
 import com.acmerobotics.roadrunner.Twist2dDual
+import com.acmerobotics.roadrunner.VelConstraint
 import org.firstinspires.ftc.teamcode.api.TriWheels.BLUE_ANGLE
 import org.firstinspires.ftc.teamcode.api.TriWheels.GREEN_ANGLE
 import org.firstinspires.ftc.teamcode.api.TriWheels.RED_ANGLE
 import org.firstinspires.ftc.teamcode.utils.PI_2
 import org.firstinspires.ftc.teamcode.utils.Polar2dDual
+import kotlin.math.abs
 
 class KiwiKinematics(val radius: Double) {
     data class WheelTicks<Param>(
@@ -32,7 +37,9 @@ class KiwiKinematics(val radius: Double) {
         val red: DualNum<Param>,
         val green: DualNum<Param>,
         val blue: DualNum<Param>,
-    )
+    ) {
+        fun all() = listOf(this.red, this.green, this.blue)
+    }
 
     fun <Param> inverse(t: PoseVelocity2dDual<Param>): WheelVelocities<Param> {
         val polar = Polar2dDual.fromCartesian(t.linearVel)
@@ -46,5 +53,21 @@ class KiwiKinematics(val radius: Double) {
             polar.radius * (greenAngle - polar.theta) + t.angVel,
             polar.radius * (blueAngle - polar.theta) + t.angVel,
         )
+    }
+
+    inner class WheelVelConstraint(val maxWheelVel: Double) : VelConstraint {
+        override fun maxRobotVel(
+            robotPose: Pose2dDual<Arclength>,
+            path: PosePath,
+            s: Double,
+        ): Double {
+            val txRobotWorld = robotPose.value().inverse()
+            val robotVelWorld = robotPose.velocity().value()
+            val robotVelRobot = txRobotWorld * robotVelWorld
+
+            return this@KiwiKinematics.inverse(
+                PoseVelocity2dDual.constant<Arclength>(robotVelRobot, 1),
+            ).all().minOf { abs(maxWheelVel / it.value()) }
+        }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
@@ -46,7 +46,7 @@ class KiwiKinematics(private val radius: Double) {
             // Sum the cartesian coordinates and divide by 1.5 coefficient.
             (rxy + gxy + bxy) / 1.5,
             // Find rotation by summing linear distance and dividing by radius.
-            (w.red + w.green + w.blue) / radius,
+            (w.red + w.green + w.blue) / this.radius,
         )
     }
 
@@ -80,12 +80,12 @@ class KiwiKinematics(private val radius: Double) {
         val greenAngle = DualNum.constant<Param>(GREEN_ANGLE, polar.theta.size())
         val blueAngle = DualNum.constant<Param>(BLUE_ANGLE, polar.theta.size())
 
-        val wheelAngVel = t.angVel / 3.0
+        val wheelLinVel = t.angVel * this.radius / 3.0
 
         return WheelVelocities(
-            polar.radius * (redAngle - polar.theta).sin() + wheelAngVel,
-            polar.radius * (greenAngle - polar.theta).sin() + wheelAngVel,
-            polar.radius * (blueAngle - polar.theta).sin() + wheelAngVel,
+            polar.radius * (redAngle - polar.theta).sin() + wheelLinVel,
+            polar.radius * (greenAngle - polar.theta).sin() + wheelLinVel,
+            polar.radius * (blueAngle - polar.theta).sin() + wheelLinVel,
         )
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
@@ -2,11 +2,14 @@ package org.firstinspires.ftc.teamcode.api.roadrunner
 
 import com.acmerobotics.roadrunner.Arclength
 import com.acmerobotics.roadrunner.DualNum
+import com.acmerobotics.roadrunner.MecanumKinematics
 import com.acmerobotics.roadrunner.Pose2dDual
 import com.acmerobotics.roadrunner.PosePath
 import com.acmerobotics.roadrunner.PoseVelocity2dDual
+import com.acmerobotics.roadrunner.TankKinematics
 import com.acmerobotics.roadrunner.Twist2dDual
 import com.acmerobotics.roadrunner.VelConstraint
+import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.api.TriWheels.BLUE_ANGLE
 import org.firstinspires.ftc.teamcode.api.TriWheels.GREEN_ANGLE
 import org.firstinspires.ftc.teamcode.api.TriWheels.RED_ANGLE
@@ -14,25 +17,42 @@ import org.firstinspires.ftc.teamcode.utils.PI_2
 import org.firstinspires.ftc.teamcode.utils.Polar2dDual
 import kotlin.math.abs
 
-class KiwiKinematics(val radius: Double) {
+/**
+ * Used to compute the various physics related to the kiwi drive (Killough platform).
+ *
+ * This was based off of [MecanumKinematics] and [TankKinematics].
+ */
+class KiwiKinematics(private val radius: Double) {
+    /**
+     * Represents the amount of ticks each wheel on the drive rotated.
+     */
     data class WheelTicks<Param>(
         val red: DualNum<Param>,
         val green: DualNum<Param>,
         val blue: DualNum<Param>,
     )
 
+    /**
+     * Calculates the position and rotation of the robot based off of the wheel ticks.
+     */
     fun <Param> forward(w: WheelTicks<Param>): Twist2dDual<Param> {
-        // TODO: Find n property of kinematics dual numbers.
-        val r = Polar2dDual(DualNum.constant(RED_ANGLE - PI_2, 4), w.red).toCartesian()
-        val g = Polar2dDual(DualNum.constant(GREEN_ANGLE - PI_2, 4), w.green).toCartesian()
-        val b = Polar2dDual(DualNum.constant(BLUE_ANGLE - PI_2, 4), w.blue).toCartesian()
+        // Calculates the cartesian coordinates of each wheel, where the magnitude is the ticks.
+        // TODO: Find n property of kinematics dual numbers, instead of defaulting to 4.
+        val rxy = Polar2dDual(DualNum.constant(RED_ANGLE - PI_2, 4), w.red).toCartesian()
+        val gxy = Polar2dDual(DualNum.constant(GREEN_ANGLE - PI_2, 4), w.green).toCartesian()
+        val bxy = Polar2dDual(DualNum.constant(BLUE_ANGLE - PI_2, 4), w.blue).toCartesian()
 
         return Twist2dDual(
-            (r + g + b) / 1.5,
+            // Sum the cartesian coordinates and divide by 1.5 coefficient.
+            (rxy + gxy + bxy) / 1.5,
+            // Find rotation by summing linear distance and dividing by radius.
             (w.red + w.green + w.blue) / radius,
         )
     }
 
+    /**
+     * Represents the velocities of each wheel on the drive.
+     */
     data class WheelVelocities<Param>(
         val red: DualNum<Param>,
         val green: DualNum<Param>,
@@ -41,6 +61,11 @@ class KiwiKinematics(val radius: Double) {
         fun all() = listOf(this.red, this.green, this.blue)
     }
 
+    /**
+     * Calculates the velocity of each wheel from the linear and angular velocity of the robot.
+     *
+     * This is the dual-form of [TriWheels.compute].
+     */
     fun <Param> inverse(t: PoseVelocity2dDual<Param>): WheelVelocities<Param> {
         val polar = Polar2dDual.fromCartesian(t.linearVel)
 
@@ -55,7 +80,8 @@ class KiwiKinematics(val radius: Double) {
         )
     }
 
-    inner class WheelVelConstraint(val maxWheelVel: Double) : VelConstraint {
+    // Slightly modified from `MecanumKinematics.WheelVelConstraint`.
+    inner class WheelVelConstraint(private val maxWheelVel: Double) : VelConstraint {
         override fun maxRobotVel(
             robotPose: Pose2dDual<Arclength>,
             path: PosePath,

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
@@ -67,7 +67,14 @@ class KiwiKinematics(private val radius: Double) {
      * This is the dual-form of [TriWheels.compute].
      */
     fun <Param> inverse(t: PoseVelocity2dDual<Param>): WheelVelocities<Param> {
-        val polar = Polar2dDual.fromCartesian(t.linearVel)
+        var polar = Polar2dDual.fromCartesian(t.linearVel)
+
+        // If X is negative...
+        if (t.linearVel.x.value() < 0) {
+            // ...make the radius negative.
+            // See https://github.com/BotsBurgh/BOTSBURGH-FTC-2024-25/pull/47#issuecomment-2266043378.
+            polar = Polar2dDual(polar.theta, -polar.radius)
+        }
 
         val redAngle = DualNum.constant<Param>(RED_ANGLE, polar.theta.size())
         val greenAngle = DualNum.constant<Param>(GREEN_ANGLE, polar.theta.size())

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
@@ -80,10 +80,12 @@ class KiwiKinematics(private val radius: Double) {
         val greenAngle = DualNum.constant<Param>(GREEN_ANGLE, polar.theta.size())
         val blueAngle = DualNum.constant<Param>(BLUE_ANGLE, polar.theta.size())
 
+        val wheelAngVel = t.angVel / 3.0
+
         return WheelVelocities(
-            polar.radius * (redAngle - polar.theta).sin() + t.angVel,
-            polar.radius * (greenAngle - polar.theta).sin() + t.angVel,
-            polar.radius * (blueAngle - polar.theta).sin() + t.angVel,
+            polar.radius * (redAngle - polar.theta).sin() + wheelAngVel,
+            polar.radius * (greenAngle - polar.theta).sin() + wheelAngVel,
+            polar.radius * (blueAngle - polar.theta).sin() + wheelAngVel,
         )
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
@@ -1,0 +1,50 @@
+package org.firstinspires.ftc.teamcode.api.roadrunner
+
+import com.acmerobotics.roadrunner.DualNum
+import com.acmerobotics.roadrunner.PoseVelocity2dDual
+import com.acmerobotics.roadrunner.Twist2dDual
+import org.firstinspires.ftc.teamcode.api.TriWheels.BLUE_ANGLE
+import org.firstinspires.ftc.teamcode.api.TriWheels.GREEN_ANGLE
+import org.firstinspires.ftc.teamcode.api.TriWheels.RED_ANGLE
+import org.firstinspires.ftc.teamcode.utils.PI_2
+import org.firstinspires.ftc.teamcode.utils.Polar2dDual
+
+class KiwiKinematics(val radius: Double) {
+    data class WheelTicks<Param>(
+        val red: DualNum<Param>,
+        val green: DualNum<Param>,
+        val blue: DualNum<Param>,
+    )
+
+    fun <Param> forward(w: WheelTicks<Param>): Twist2dDual<Param> {
+        // TODO: Find n property of kinematics dual numbers.
+        val r = Polar2dDual(DualNum.constant(RED_ANGLE - PI_2, 4), w.red).toCartesian()
+        val g = Polar2dDual(DualNum.constant(GREEN_ANGLE - PI_2, 4), w.green).toCartesian()
+        val b = Polar2dDual(DualNum.constant(BLUE_ANGLE - PI_2, 4), w.blue).toCartesian()
+
+        Twist2dDual(
+            (r + g + b) / 1.5,
+            TODO("Calculate angle from wheel ticks"),
+        )
+    }
+
+    data class WheelVelocities<Param>(
+        val red: DualNum<Param>,
+        val green: DualNum<Param>,
+        val blue: DualNum<Param>,
+    )
+
+    fun <Param> inverse(t: PoseVelocity2dDual<Param>): WheelVelocities<Param> {
+        val polar = Polar2dDual.fromCartesian(t.linearVel)
+
+        val redAngle = DualNum.constant<Param>(RED_ANGLE, polar.theta.size())
+        val greenAngle = DualNum.constant<Param>(GREEN_ANGLE, polar.theta.size())
+        val blueAngle = DualNum.constant<Param>(BLUE_ANGLE, polar.theta.size())
+
+        return WheelVelocities(
+            polar.radius * (redAngle - polar.theta) + t.angVel,
+            polar.radius * (greenAngle - polar.theta) + t.angVel,
+            polar.radius * (blueAngle - polar.theta) + t.angVel,
+        )
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
@@ -27,9 +27,9 @@ class KiwiKinematics(val radius: Double) {
         val g = Polar2dDual(DualNum.constant(GREEN_ANGLE - PI_2, 4), w.green).toCartesian()
         val b = Polar2dDual(DualNum.constant(BLUE_ANGLE - PI_2, 4), w.blue).toCartesian()
 
-        Twist2dDual(
+        return Twist2dDual(
             (r + g + b) / 1.5,
-            TODO("Calculate angle from wheel ticks"),
+            (w.red + w.green + w.blue) / radius,
         )
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiKinematics.kt
@@ -74,9 +74,9 @@ class KiwiKinematics(private val radius: Double) {
         val blueAngle = DualNum.constant<Param>(BLUE_ANGLE, polar.theta.size())
 
         return WheelVelocities(
-            polar.radius * (redAngle - polar.theta) + t.angVel,
-            polar.radius * (greenAngle - polar.theta) + t.angVel,
-            polar.radius * (blueAngle - polar.theta) + t.angVel,
+            polar.radius * (redAngle - polar.theta).sin() + t.angVel,
+            polar.radius * (greenAngle - polar.theta).sin() + t.angVel,
+            polar.radius * (blueAngle - polar.theta).sin() + t.angVel,
         )
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Polar2d.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utils/Polar2d.kt
@@ -60,7 +60,7 @@ data class Polar2dDual<Param>(val theta: DualNum<Param>, val radius: DualNum<Par
             val theta = v.atan2()
 
             // Calculate the hypotenuse.
-            val radius = v.x * v.x + v.y * v.y
+            val radius = (v.x * v.x + v.y * v.y).sqrt()
 
             return Polar2dDual(theta, radius)
         }


### PR DESCRIPTION
This creates `KiwiKinematics`, which is the kiwi drive-form of `MecanumKinematics` and `TankKinematics` from Road Runner. This class can be used to convert between the position + rotation and the ticks of each wheel.