### PR TITLE
Create `KiwiLocalizer`

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.kt
@@ -45,5 +45,9 @@ object RobotConfig {
         /** The radius of the robot, from the center to the wheel. */
         @JvmField
         var RADIUS: Double = 1.0
+
+        /** The amount of inches a wheel travels in a single tick. */
+        @JvmField
+        var INCHES_PER_TICK: Double = 1.0
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.kt
@@ -40,6 +40,7 @@ object RobotConfig {
         var ROTATE_SPEED: Double = 0.3
     }
 
+    // TODO: Set robot radius and inches per tick.
     @Config
     object KiwiLocalizer {
         /** The radius of the robot, from the center to the wheel. */

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.kt
@@ -39,4 +39,11 @@ object RobotConfig {
         @JvmField
         var ROTATE_SPEED: Double = 0.3
     }
+
+    @Config
+    object KiwiLocalizer {
+        /** The radius of the robot, from the center to the wheel. */
+        @JvmField
+        var RADIUS: Double = 1.0
+    }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
@@ -17,6 +17,11 @@ import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.core.API
 import org.firstinspires.ftc.teamcode.utils.RobotConfig
 
+/**
+ * An [API] used to detect where the robot is and how much it has moved.
+ *
+ * @see update
+ */
 object KiwiLocalizer : API() {
     override val dependencies = setOf(TriWheels)
 
@@ -58,32 +63,42 @@ object KiwiLocalizer : API() {
         this.kinematics = KiwiKinematics(RobotConfig.KiwiLocalizer.RADIUS)
     }
 
+    /**
+     * Returns a [Twist2dDual] representing how much the robot's position and heading has changed
+     * compared to the previous time this function was called.
+     */
     fun update(): Twist2dDual<Time> {
+        // Find position and velocity of each wheel.
         val redPosVel = this.red.getPositionAndVelocity()
         val greenPosVel = this.green.getPositionAndVelocity()
         val bluePosVel = this.blue.getPositionAndVelocity()
 
+        // Find heading of IMU.
         val angles = this.imu.robotYawPitchRollAngles
-
         val heading = Rotation2d.fromDouble(angles.getYaw(AngleUnit.RADIANS))
 
         if (this.firstUpdate) {
             this.firstUpdate = false
 
+            // Initialize last position and heading as current values.
             this.lastRedPos = redPosVel.position
             this.lastGreenPos = greenPosVel.position
             this.lastBluePos = bluePosVel.position
 
             this.lastHeading = heading
 
+            // Return a zeroed twist, equivalent no change.
             return Twist2dDual(
                 Vector2dDual.constant(Vector2d(0.0, 0.0), 2),
                 DualNum.constant(0.0, 2),
             )
         }
 
+        // Find the change in heading.
         val headingDelta = heading - this.lastHeading
 
+        // Calculate the twist: how much the robot has moved between the current and previous call
+        // to `update()`.
         val twist =
             this.kinematics.forward(
                 KiwiKinematics.WheelTicks(
@@ -108,12 +123,14 @@ object KiwiLocalizer : API() {
                 ),
             )
 
+        // Update last position and heading to current values.
         this.lastRedPos = redPosVel.position
         this.lastGreenPos = greenPosVel.position
         this.lastBluePos = bluePosVel.position
 
         this.lastHeading = heading
 
+        // Return the calculated twist, but replace the calculated angle with the one from the IMU.
         return Twist2dDual(twist.line, DualNum.cons(headingDelta, twist.angle.drop(1)))
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
@@ -36,9 +36,6 @@ object KiwiLocalizer : API() {
 
     private var firstUpdate = true
 
-    // TODO: Find this value
-    private const val inPerTick = 0.0
-
     override fun init(opMode: OpMode) {
         super.init(opMode)
 
@@ -90,9 +87,24 @@ object KiwiLocalizer : API() {
         val twist =
             this.kinematics.forward(
                 KiwiKinematics.WheelTicks(
-                    DualNum<Time>(doubleArrayOf((redPosVel.position - this.lastRedPos).toDouble(), redPosVel.velocity.toDouble())) * this.inPerTick,
-                    DualNum<Time>(doubleArrayOf((greenPosVel.position - this.lastGreenPos).toDouble(), greenPosVel.velocity.toDouble())) * this.inPerTick,
-                    DualNum<Time>(doubleArrayOf((bluePosVel.position - this.lastBluePos).toDouble(), bluePosVel.velocity.toDouble())) * this.inPerTick,
+                    DualNum<Time>(
+                        doubleArrayOf(
+                            (redPosVel.position - this.lastRedPos).toDouble(),
+                            redPosVel.velocity.toDouble(),
+                        ),
+                    ) * RobotConfig.KiwiLocalizer.INCHES_PER_TICK,
+                    DualNum<Time>(
+                        doubleArrayOf(
+                            (greenPosVel.position - this.lastGreenPos).toDouble(),
+                            greenPosVel.velocity.toDouble(),
+                        ),
+                    ) * RobotConfig.KiwiLocalizer.INCHES_PER_TICK,
+                    DualNum<Time>(
+                        doubleArrayOf(
+                            (bluePosVel.position - this.lastBluePos).toDouble(),
+                            bluePosVel.velocity.toDouble(),
+                        ),
+                    ) * RobotConfig.KiwiLocalizer.INCHES_PER_TICK,
                 ),
             )
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
@@ -15,6 +15,7 @@ import com.qualcomm.robotcore.hardware.IMU
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.core.API
+import org.firstinspires.ftc.teamcode.utils.RobotConfig
 
 object KiwiLocalizer : API() {
     override val dependencies = setOf(TriWheels)
@@ -57,8 +58,7 @@ object KiwiLocalizer : API() {
         )
         this.imu.resetYaw()
 
-        // TODO: Set kiwi radius from `RobotConfig`.
-        this.kinematics = KiwiKinematics(1.0)
+        this.kinematics = KiwiKinematics(RobotConfig.KiwiLocalizer.RADIUS)
     }
 
     fun update(): Twist2dDual<Time> {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
@@ -1,0 +1,107 @@
+package org.firstinspires.ftc.teamcode.api.roadrunner
+
+import com.acmerobotics.roadrunner.DualNum
+import com.acmerobotics.roadrunner.Rotation2d
+import com.acmerobotics.roadrunner.Time
+import com.acmerobotics.roadrunner.Twist2dDual
+import com.acmerobotics.roadrunner.Vector2d
+import com.acmerobotics.roadrunner.Vector2dDual
+import com.acmerobotics.roadrunner.ftc.Encoder
+import com.acmerobotics.roadrunner.ftc.OverflowEncoder
+import com.acmerobotics.roadrunner.ftc.RawEncoder
+import com.qualcomm.hardware.rev.RevHubOrientationOnRobot
+import com.qualcomm.robotcore.eventloop.opmode.OpMode
+import com.qualcomm.robotcore.hardware.IMU
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
+import org.firstinspires.ftc.teamcode.api.TriWheels
+import org.firstinspires.ftc.teamcode.core.API
+
+object KiwiLocalizer : API() {
+    override val dependencies = setOf(TriWheels)
+
+    private lateinit var red: Encoder
+    private lateinit var green: Encoder
+    private lateinit var blue: Encoder
+
+    private lateinit var imu: IMU
+
+    private lateinit var kinematics: KiwiKinematics
+
+    private var lastRedPos = 0
+    private var lastGreenPos = 0
+    private var lastBluePos = 0
+
+    private var lastHeading = Rotation2d.fromDouble(0.0)
+
+    private var firstUpdate = true
+
+    // TODO: Find this value
+    private const val inPerTick = 0.0
+
+    override fun init(opMode: OpMode) {
+        super.init(opMode)
+
+        this.red = OverflowEncoder(RawEncoder(TriWheels.red))
+        this.green = OverflowEncoder(RawEncoder(TriWheels.green))
+        this.blue = OverflowEncoder(RawEncoder(TriWheels.blue))
+
+        this.imu = this.opMode.hardwareMap.get(IMU::class.java, "imu")
+        this.imu.initialize(
+            IMU.Parameters(
+                // TODO: Select REV Hub orientation.
+                RevHubOrientationOnRobot(
+                    RevHubOrientationOnRobot.LogoFacingDirection.FORWARD,
+                    RevHubOrientationOnRobot.UsbFacingDirection.UP,
+                ),
+            ),
+        )
+        this.imu.resetYaw()
+
+        // TODO: Set kiwi radius from `RobotConfig`.
+        this.kinematics = KiwiKinematics(1.0)
+    }
+
+    fun update(): Twist2dDual<Time> {
+        val redPosVel = this.red.getPositionAndVelocity()
+        val greenPosVel = this.green.getPositionAndVelocity()
+        val bluePosVel = this.blue.getPositionAndVelocity()
+
+        val angles = this.imu.robotYawPitchRollAngles
+
+        val heading = Rotation2d.fromDouble(angles.getYaw(AngleUnit.RADIANS))
+
+        if (this.firstUpdate) {
+            this.firstUpdate = false
+
+            this.lastRedPos = redPosVel.position
+            this.lastGreenPos = greenPosVel.position
+            this.lastBluePos = bluePosVel.position
+
+            this.lastHeading = heading
+
+            return Twist2dDual(
+                Vector2dDual.constant(Vector2d(0.0, 0.0), 2),
+                DualNum.constant(0.0, 2),
+            )
+        }
+
+        val headingDelta = heading - this.lastHeading
+
+        val twist =
+            this.kinematics.forward(
+                KiwiKinematics.WheelTicks(
+                    DualNum<Time>(doubleArrayOf((redPosVel.position - this.lastRedPos).toDouble(), redPosVel.velocity.toDouble())) * this.inPerTick,
+                    DualNum<Time>(doubleArrayOf((greenPosVel.position - this.lastGreenPos).toDouble(), greenPosVel.velocity.toDouble())) * this.inPerTick,
+                    DualNum<Time>(doubleArrayOf((bluePosVel.position - this.lastBluePos).toDouble(), bluePosVel.velocity.toDouble())) * this.inPerTick,
+                ),
+            )
+
+        this.lastRedPos = redPosVel.position
+        this.lastGreenPos = greenPosVel.position
+        this.lastBluePos = bluePosVel.position
+
+        this.lastHeading = heading
+
+        return Twist2dDual(twist.line, DualNum.cons(headingDelta, twist.angle.drop(1)))
+    }
+}


### PR DESCRIPTION
`KiwiLocalizer` is an API used to find the position of the robot based on the rotation of the wheels. Think of it as a step up from `KiwiKinematics`, introduced in #47.

Much of this implementation was adapted from [`MecanumDrive.DriveLocalizer`](https://github.com/acmerobotics/road-runner-quickstart/blob/af672c78077e5c37b105a42a422f6907c9a56bea/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java#L125) from Road Runner's quickstart.