### PR TITLE
Fix `RobotConfig`'s package

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.kt
@@ -2,7 +2,7 @@
 // SCREAMING_SNAKE_CASE for them instead of `ktlint`'s desired lowerCamelCase.
 @file:Suppress("ktlint:standard:property-naming")
 
-package org.firstinspires.ftc.teamcode.utils
+package org.firstinspires.ftc.teamcode
 
 import com.acmerobotics.dashboard.config.Config
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/CsvLogging.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/CsvLogging.kt
@@ -2,8 +2,8 @@ package org.firstinspires.ftc.teamcode.api
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import org.firstinspires.ftc.robotcore.internal.system.AppUtil
-import org.firstinspires.ftc.teamcode.core.API
 import org.firstinspires.ftc.teamcode.RobotConfig
+import org.firstinspires.ftc.teamcode.core.API
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/CsvLogging.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/CsvLogging.kt
@@ -3,7 +3,7 @@ package org.firstinspires.ftc.teamcode.api
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import org.firstinspires.ftc.robotcore.internal.system.AppUtil
 import org.firstinspires.ftc.teamcode.core.API
-import org.firstinspires.ftc.teamcode.utils.RobotConfig
+import org.firstinspires.ftc.teamcode.RobotConfig
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiDrive.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiDrive.kt
@@ -14,7 +14,7 @@ import com.acmerobotics.roadrunner.TurnConstraints
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.api.Voltage
 import org.firstinspires.ftc.teamcode.core.API
-import org.firstinspires.ftc.teamcode.utils.RobotConfig
+import org.firstinspires.ftc.teamcode.RobotConfig
 
 object KiwiDrive : API() {
     override val dependencies = setOf(TriWheels, KiwiLocalizer, Voltage)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiDrive.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiDrive.kt
@@ -11,10 +11,10 @@ import com.acmerobotics.roadrunner.ProfileParams
 import com.acmerobotics.roadrunner.TrajectoryActionBuilder
 import com.acmerobotics.roadrunner.TrajectoryBuilderParams
 import com.acmerobotics.roadrunner.TurnConstraints
+import org.firstinspires.ftc.teamcode.RobotConfig
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.api.Voltage
 import org.firstinspires.ftc.teamcode.core.API
-import org.firstinspires.ftc.teamcode.RobotConfig
 
 object KiwiDrive : API() {
     override val dependencies = setOf(TriWheels, KiwiLocalizer, Voltage)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
@@ -15,7 +15,7 @@ import com.qualcomm.robotcore.hardware.IMU
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.core.API
-import org.firstinspires.ftc.teamcode.utils.RobotConfig
+import org.firstinspires.ftc.teamcode.RobotConfig
 
 /**
  * An [API] used to detect where the robot is and how much it has moved.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/roadrunner/KiwiLocalizer.kt
@@ -13,9 +13,9 @@ import com.qualcomm.hardware.rev.RevHubOrientationOnRobot
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.hardware.IMU
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
+import org.firstinspires.ftc.teamcode.RobotConfig
 import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.core.API
-import org.firstinspires.ftc.teamcode.RobotConfig
 
 /**
  * An [API] used to detect where the robot is and how much it has moved.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMain.kt
@@ -3,7 +3,7 @@ package org.firstinspires.ftc.teamcode.teleOp
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
 import org.firstinspires.ftc.teamcode.api.TriWheels
-import org.firstinspires.ftc.teamcode.utils.RobotConfig
+import org.firstinspires.ftc.teamcode.RobotConfig
 import kotlin.math.PI
 import kotlin.math.atan2
 import kotlin.math.sqrt

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMain.kt
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.teleOp
+package org.firstinspires.ftc.teamcode.teleop
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMain.kt
@@ -2,8 +2,8 @@ package org.firstinspires.ftc.teamcode.teleOp
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
-import org.firstinspires.ftc.teamcode.api.TriWheels
 import org.firstinspires.ftc.teamcode.RobotConfig
+import org.firstinspires.ftc.teamcode.api.TriWheels
 import kotlin.math.PI
 import kotlin.math.atan2
 import kotlin.math.sqrt


### PR DESCRIPTION
The `package` line of a Kotlin file declares where an import should look for a file, and usually corresponds to the directory structure that file is within. This wasn't the case of `RobotConfig`, though.

While it is within the `teamcode` folder, its `package` line said it was within `teamcode/utils`. This PR fixes that and all related imports.