### PR TITLE
Update to FtcRobotController v10.1.1

### DIFF
--- a/FtcRobotController/build.gradle
+++ b/FtcRobotController/build.gradle
@@ -12,7 +12,11 @@ android {
         buildConfigField("String", "APP_BUILD_TIME", "\"" + (new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.ROOT).format(new Date())) + "\"")
     }
 
-    compileSdkVersion 29
+    buildFeatures {
+        buildConfig = true
+    }
+
+    compileSdkVersion 30
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/FtcRobotController/src/main/AndroidManifest.xml
+++ b/FtcRobotController/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="56"
-          android:versionName="10.1">
+    android:versionCode="57"
+          android:versionName="10.1.1">
 
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 //
 // build.gradle in TeamCode
 //
@@ -24,6 +26,12 @@ android {
 
     packagingOptions {
         jniLibs.useLegacyPackaging = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
     }
 }
 

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -20,7 +20,7 @@ import java.util.regex.Pattern
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion = 29
+    compileSdkVersion = 30
 
     signingConfigs {
         release {
@@ -108,9 +108,6 @@ android {
     packagingOptions {
         pickFirst "**/*.so"
     }
-    sourceSets.main {
-        jni.srcDirs = []
-        jniLibs.srcDir rootProject.file("libs")
-    }
+
     ndkVersion "21.3.6528147"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@ android.useAndroidX=true
 # We no longer need to auto-convert third-party libraries to use AndroidX, which slowed down the build.
 android.enableJetifier=false
 
+android.nonTransitiveRClass=false
+
 # Allow Gradle to use up to 2 GiB of RAM.
 org.gradle.jvmargs=-Xmx2048M
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Do not modify this unless you want to have a really bad time.
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.7.0"
 
 # Kotlin language version.
 kotlin = "2.0.0"
@@ -9,7 +9,7 @@ kotlin = "2.0.0"
 kotlinter = "4.1.1"
 
 # FTC libraries.
-ftc = "10.1.0"
+ftc = "10.1.1"
 
 # FTC associated libraries.
 androidxAppCompat = "1.3.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat May 25 15:05:39 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This updates to FtcRobotController [v10.1.1](https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/tag/v10.1.1), which includes a fix for running on Android Studio Ladybug.

To update I followed the same steps in #45.