### PR TITLE
Rename the main teleop and autonomous opmodes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/AutoMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/AutoMain.kt
@@ -6,7 +6,7 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 /**
  * This is the main code for the autonomous segment of the game.
  */
-@Autonomous(name = "Main")
+@Autonomous(name = "AutoMain")
 class AutoMain : LinearOpMode() {
     // This function is the entrypoint into our code. It is run when the "Init" button is pressed.
     override fun runOpMode() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMain.kt
@@ -8,7 +8,7 @@ import kotlin.math.PI
 import kotlin.math.atan2
 import kotlin.math.sqrt
 
-@TeleOp(name = "Main")
+@TeleOp(name = "TeleOpMain")
 class TeleOpMain : OpMode() {
     override fun init() {
         TriWheels.init(this)


### PR DESCRIPTION
Both were named "Main", which caused a warning on the driver station.